### PR TITLE
fix(equality): fall back to reflect.DeepEquals

### DIFF
--- a/tagged_value.go
+++ b/tagged_value.go
@@ -140,5 +140,5 @@ func isEqual[T any](a, b T) bool {
 	if va.Type().Kind() == reflect.Func {
 		return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
 	}
-	return false
+	return reflect.DeepEqual(a, b)
 }

--- a/tagged_value_test.go
+++ b/tagged_value_test.go
@@ -6,6 +6,44 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_TaggedInterfaces(t *testing.T) {
+	type t1 struct {
+		name  string
+		field []string // not comparable
+	}
+
+	a := []string{"a"}
+	b := []string{"b"}
+	c := []string{"c"}
+	set1 := TaggedValueSet[any]{TaggedValue[any]{Value: t1{name: "a"}, Tags: a}, TaggedValue[any]{Value: t1{name: "b"}, Tags: b}}
+	set2 := TaggedValueSet[any]{TaggedValue[any]{Value: t1{name: "c"}, Tags: c}}
+
+	s := set2.Join(set2...)
+	require.Len(t, s, 1)
+
+	s = set1.Join(set2...)
+	require.Len(t, s, 3)
+
+	s = s.Join(set1...).Join(set2...)
+	require.Len(t, s, 3)
+}
+
+func Test_TaggedFuncs(t *testing.T) {
+	a := func() {}
+	b := func() {}
+	set1 := TaggedValueSet[any]{TaggedValue[any]{Value: a}}
+	set2 := TaggedValueSet[any]{TaggedValue[any]{Value: b}}
+
+	s := set2.Join(set2...)
+	require.Len(t, s, 1)
+
+	s = set1.Join(set2...)
+	require.Len(t, s, 2)
+
+	s = s.Join(set1...).Join(set2...)
+	require.Len(t, s, 2)
+}
+
 func Test_Tagged(t *testing.T) {
 	set := TaggedValueSet[int]{
 		NewTaggedValue(1, "one"),


### PR DESCRIPTION
This PR fixes an issue where duplicates syft sources were in the tagged set. This change prevents duplicates by falling back to reflect.DeepEquals in the equality check.