### PR TITLE
chore(deps): restore Go version to 1.21.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/go-collections
 
-go 1.26.2
+go 1.21.0
 
 require github.com/stretchr/testify v1.11.1
 


### PR DESCRIPTION
Restores the go directive in go.mod to 1.21.0 (pre-#12). Bumped in #12 (merge fc3f7459f372dcf412f1a36ab59f34aa598c2733).